### PR TITLE
Mn 2018 filter for last login in django user admin

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -1,0 +1,12 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+
+
+class CustomUserAdmin(UserAdmin):
+    list_display = UserAdmin.list_display + ('last_login',)
+    list_filter = UserAdmin.list_filter + ('last_login',)
+
+
+admin.site.unregister(User)
+admin.site.register(User, CustomUserAdmin)

--- a/tempelhof/settings/base.py
+++ b/tempelhof/settings/base.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'apps.blog',
     'apps.docs',
     'apps.images',
+    'apps.users',
 
     'wagtail.wagtailforms',
     'wagtail.wagtailredirects',


### PR DESCRIPTION
By this users can be filtered by last-login date in django admin and if they have not logged in at all they can be deleted.