### PR TITLE
beta-label: removing beta label from header

### DIFF
--- a/apps/home/templates/home/includes/header.html
+++ b/apps/home/templates/home/includes/header.html
@@ -5,7 +5,6 @@
     <nav class="l-wrapper header__container">
         <span class="header__site-name">
             {{ self.get_site.site_name }}
-            <span class="label">Beta-Version</span>
         </span>
         <button class="header__toggle button button--light">
             <i class="fa fa-bars" aria-label="{% trans 'Menu' %}"></i>


### PR DESCRIPTION
local site looks pretty different from prod site but have tested code removal on prod site in browser and works fine