### PR TITLE
Fix for css-loader 5.2.4 (config adjustments)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/fontawesome-free": "5.15.3",
     "autoprefixer": "10.2.5",
     "babel-loader": "8.2.2",
-    "css-loader": "4.3.0",
+    "css-loader": "5.2.4",
     "copy-webpack-plugin": "7.0.0",
     "file-loader": "6.2.0",
     "flatpickr": "4.6.9",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -70,6 +70,7 @@ module.exports = {
         test: /(fonts|files)\/.*\.(svg|woff2?|ttf|eot|otf)(\?.*)?$/,
         loader: 'file-loader',
         options: {
+          import: false,
           name: 'fonts/[name].[ext]'
         }
       },
@@ -77,6 +78,7 @@ module.exports = {
         test: /\.svg$|\.png$/,
         loader: 'file-loader',
         options: {
+          import: false,
           name: 'images/[name].[ext]'
         }
       }


### PR DESCRIPTION
With updating to webpack 5+ and latest css loader url and import resoving
changed. In order to keep our paths we turn off these resolvings for url and import
in the config